### PR TITLE
Holoport preflight

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 result*
 .idea/
+.vagrant/
+Vagrantfile
+*~

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+SHELL		= bash
+
+.PHONY: all test build install
+
+all: test
+
+# test -- collect up the HoloPortOS source, and use it to execute a nixos-rebuild switch
+test:
+	HOLOPORT_MODULES_URL=file://$$(		\
+	    nix-build -E '				\
+		with import <nixpkgs> {};		\
+		runCommand "holoportos"			\
+		    { src = lib.cleanSource ./.; }	\
+		    "					\
+			mkdir $$out;			\
+			tar caf $$out/holoportos.tar.gz -C $$(dirname $$src) $$(basename $$src) \
+		    "					\
+		'					\
+		--no-out-link				\
+	)/holoportos.tar.gz nixos-rebuild switch --show-trace

--- a/modules/base.nix
+++ b/modules/base.nix
@@ -176,6 +176,7 @@ in
         yarn
         zeromq4
         rsync
+        utillinux
       ];
       programs.bash.shellAliases = {
         htst = "${hptest}/bin/hptest";

--- a/modules/base.nix
+++ b/modules/base.nix
@@ -246,13 +246,15 @@ in
 
       # HoloPort Preflight checks must occur before ZeroTier and Holo / Holochain startup (or any
       # other service which may have its configuration modified by the holoport-preflight).
-      # Holochain Activation depends on running the "preflight" configuration checklist (to bring
-      # the basic HoloPort OS configuration up to standard), and then the Activation required for
-      # Holo / Holochain.  If either of these fail, the HoloPort will *not* be considered
-      # "Activated".
+      # Furthermore, these services must be restarted whenever the Preflight service is run (eg. on
+      # automatic HoloPortOS updates).  Holochain Activation depends on running the "preflight"
+      # configuration checklist (to bring the basic HoloPort OS configuration up to standard), and
+      # then the Activation required for Holo / Holochain.  If either of these fail, the HoloPort
+      # will *not* be considered "Activated".
       systemd.services.holoport-preflight = {
         enable          = true;
         before          = [ "zerotierone.service" "sshd.service" ];
+        requiredBy      = [ "zerotierone.service" "sshd.service" ];
         path            = [ pkgs.rsync pkgs.utillinux ];
         serviceConfig   = {
           Type          = "oneshot";

--- a/modules/base.nix
+++ b/modules/base.nix
@@ -176,7 +176,6 @@ in
         yarn
         zeromq4
         rsync
-        util-linux
       ];
       programs.bash.shellAliases = {
         htst = "${hptest}/bin/hptest";

--- a/modules/base.nix
+++ b/modules/base.nix
@@ -75,39 +75,14 @@ let
     echo "All tests have completed"
     cat hpplustest.txt | less
     '';
-  systemd-activation = pkgs.writeShellScriptBin "systemd-activation" ''
-    if [ ! -d /var/lib/holochain ] ;
-    then mkdir /var/lib/holochain; chown -R holochain:holochain /var/lib/holochain;
-    fi
 
-    if [ ! -d /home/holochain/.n3h ] ;
-    then mkdir /home/holochain/.n3h; chown -R holochain:holochain /home/holochain/.n3h;
-    fi
+  holoport-preflight = pkgs.writeShellScriptBin "holoport-preflight" (
+    builtins.readFile ../scripts/holoport-preflight.sh
+  );
+  holochain-activation = pkgs.writeShellScriptBin "holochain-activation" (
+    builtins.readFile ../scripts/holochain-activation.sh
+  );
 
-    if [ ! -d /home/holochain/.config/holochain/keys ] ;
-    then mkdir -p /home/holochain/.config/holochain/keys; chown -R holochain:holochain /home/holochain/.config/holochain/keys;
-    fi
-
-
-    if [ ! -f /var/lib/holochain/conductor-config.toml ];
-    then cat <<- EOF > /var/lib/holochain/conductor-config.toml
-    persistence_dir = "/var/lib/holochain"
-    agents = []
-    dnas = []
-    instances = []
-    interfaces = []
-    bridges = []
-
-    [logger]
-    type = "debug"
-
-    EOF
-    fi
-    chown holochain:holochain /var/lib/holochain/conductor-config.toml;
-    chown -R holochain:holochain /var/lib/holochain;
-    chmod 0775 /var/lib/holochain/conductor-config.toml;
-
-  '';
 in
 {
   options = {
@@ -200,6 +175,8 @@ in
         stress-ng
         yarn
         zeromq4
+        rsync
+        util-linux
       ];
       programs.bash.shellAliases = {
         htst = "${hptest}/bin/hptest";
@@ -266,21 +243,32 @@ in
           StandardOutput = "journal";
         };
       };
-      systemd.timers.systemd-activation = {
-        description = "run systemd-activation every 30 seconds";
-        wantedBy = [ "timers.target" ]; # enable it & auto start it
 
-        timerConfig = {
-          OnCalendar = "*:*:0/30";
+      # HoloPort Preflight checks must occur before ZeroTier and Holo / Holochain startup (or any
+      # other service which may have its configuration modified by the holoport-preflight).
+      # Holochain Activation depends on running the "preflight" configuration checklist (to bring
+      # the basic HoloPort OS configuration up to standard), and then the Activation required for
+      # Holo / Holochain.  If either of these fail, the HoloPort will *not* be considered
+      # "Activated".
+      systemd.services.holoport-preflight = {
+        enable          = true;
+        before          = [ "zerotierone.service" "sshd.service" ];
+        serviceConfig   = {
+          Type          = "oneshot";
+          User          = "root";
+          ExecStart     = '' ${holoport-preflight}/bin/holoport-preflight '';
+          StandardOutput= "journal";
         };
       };
-      systemd.services.systemd-activation = {
-        enable = true;
-        serviceConfig = {
-          Type = "oneshot";
-          User = "root";
-          ExecStart = '' ${systemd-activation}/bin/systemd-activation '';
-          StandardOutput = "journal";
+      systemd.services.holochain-activation = {
+        enable          = true;
+        wants           = [ "holoport-preflight.service" ];
+        after           = [ "holoport-preflight.service" ];
+        serviceConfig   = {
+          Type          = "oneshot";
+          User          = "root";
+          ExecStart     = '' ${holochain-activation}/bin/holochain-activation '';
+          StandardOutput= "journal";
         };
       };
       #not used yet
@@ -288,11 +276,14 @@ in
       #services.osquery.loggerPath = "/var/log/osquery/logs";
       #services.osquery.pidfile = "/var/run/osqueryd.pid";
       networking.firewall.allowedTCPPorts = [ 80 443 1111 2222 3333 8800 8880 8888 48080 ];
+
+      # Holochain can't come up until filesystems are available, ZeroTier is started, and the HoloPort
+      # is Activated (configuration is confirmed to be valid).
       systemd.services.holochain = {
           description = "Holochain conductor service";
-          after = [ "local-fs.target" "network.target" "systemd-activation.service" ];
+          after = [ "local-fs.target" "zerotierone.service" "holochain-activation.service" ];
           wantedBy = [ "multi-user.target" ];
-          requires = [ "systemd-activation.service" ];
+          requires = [ "holochain-activation.service" ];
           environment = {
              NIX_STORE = "/nix/store";
              USER = "holochain";
@@ -323,6 +314,7 @@ in
         enable = true;
         joinNetworks = ["93afae5963c547f1"];
       };
+
       services.nginx = {
               enable = true;
       recommendedOptimisation = true;

--- a/modules/base.nix
+++ b/modules/base.nix
@@ -253,6 +253,7 @@ in
       systemd.services.holoport-preflight = {
         enable          = true;
         before          = [ "zerotierone.service" "sshd.service" ];
+        path            = [ pkgs.rsync pkgs.utillinux ];
         serviceConfig   = {
           Type          = "oneshot";
           User          = "root";

--- a/scripts/holochain-activation.sh
+++ b/scripts/holochain-activation.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+# 
+# holochain-activation -- Activate the HoloPort for Holo / Holochain
+#
+# DESCRIPTION
+# 
+#     Perform any configurations required to make the HoloPortOS ready to run Holo / Holochain.
+# Assumes that the basic HoloPortOS configuration is sane (see: holoport-preflight).
+# 
+
+# make_directory dir [user:group]
+make_directory() {
+    if [ ! -d "${1}" ]; then
+	mkdir -p "${1}"
+	[ -z "${2}" ] || chown -R "${2}" "${1}"
+    fi
+}
+
+HC_PERS=/var/lib/holochain
+HC_HOME=/home/holochain
+HC_KEYS=${HC_HOME}/.config/holochain/keys
+HC_COND=${HC_PERS}/conductor-config.toml
+
+make_directory "${HC_PERS}"      holochain:holochain
+make_directory "${HC_HOME}/.n3h" holochain:holochain
+make_directory "${HC_KEYS}"      holochain:holochain
+
+if [ ! -f "${HC_COND}" ]; then
+    cat <<- EOF > "${HC_COND}"
+	persistence_dir = "${HC_PERS}"
+	agents = []
+	dnas = []
+	instances = []
+	interfaces = []
+	bridges = []
+
+	[logger]
+	type = "debug"
+EOF
+    chown holochain:holochain "${HC_COND}"
+    chmod 0775                "${HC_COND}"
+fi

--- a/scripts/holochain-activation.sh
+++ b/scripts/holochain-activation.sh
@@ -1,4 +1,3 @@
-#!/usr/bin/env bash
 
 # 
 # holochain-activation -- Activate the HoloPort for Holo / Holochain

--- a/scripts/holoport-preflight.sh
+++ b/scripts/holoport-preflight.sh
@@ -1,4 +1,3 @@
-#!/usr/bin/env bash
 
 # 
 # holoport-preflight -- Ensure that known mutable HoloPortOS configuration issues are corrected

--- a/scripts/holoport-preflight.sh
+++ b/scripts/holoport-preflight.sh
@@ -89,7 +89,10 @@ case "${STATE}" in
 	    (( DRYRUN )) || rm -f "${f}"
 	done
 	;& # fall thru
-    # ... Add each new STAT
+
+    # Add each historical STATE here, each falling thru to the next, implementing the checks/fixes
+    # required to upgrade to the next state.
+
     ${CURRENT})
         log "HoloPortOS Configuration State is CURRENT: ${CURRENT}"
 	;;

--- a/scripts/holoport-preflight.sh
+++ b/scripts/holoport-preflight.sh
@@ -17,7 +17,14 @@
 #
 #     As CURRENT is advanced, remember to add the last version to the `case "${STATE}" in`, below,
 # or holoport-preflight will begin to fail to keep the system up-to-date.
-#
+# 
+# WARNING
+# 
+#     It is recommended that this script *not* exit with a non-zero exit value, to avoid interfering
+# with later systemd services.  It should make a best-effort attempt to update the system, and warn
+# about persistent problems.  If an important update cannot be effected, then it is best to simply
+# *leave* the PREFLIGHT file as-is, and have the script re-issue an explanatory warning on each run.
+# 
 
 # Current version of preflight checklist.
 CURRENT=v1
@@ -39,7 +46,6 @@ while [[ "${1#-}" != "${1}" ]]; do
 	    ;;
 	*)
 	    $ERR "Invalid option: ${1}"
-	    exit 1
     esac
     shift
 done

--- a/scripts/holoport-preflight.sh
+++ b/scripts/holoport-preflight.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+
+# 
+# holoport-preflight -- Ensure that known mutable HoloPortOS configuration issues are corrected
+# 
+# DESCRIPTION
+# 
+#     As HoloPortOS evolves, we will likely discover that certain mutable state and configuration
+# data needs to be adjusted.  The underlying software delivered is controlled by Nix configuration,
+# and can be assumed to be consistent and valid.  However, the system is controlled by various
+# mutable configuration and state files, which may (for various reasons) end up containing invalid,
+# inconsistent or otherwise incorrect data.
+# 
+#     When we detect such a situation, we can place tests here to mitigate the issue.
+# 
+#     After bringing a node up to a certain level of holoport-preflight, we'll output the CURRENT
+# state to /var/lib/holoport/preflight.
+#
+#     As CURRENT is advanced, remember to add the last version to the `case "${STATE}" in`, below,
+# or holoport-preflight will begin to fail to keep the system up-to-date.
+#
+
+# Current version of preflight checklist.
+CURRENT=v1
+
+# Option flags. Set DRYRUN to non-zero value to avoid performing file mutations.
+DRYRUN=
+
+# Persistence files for holoport-preflight, zerotier, etc.
+HP_PERS="/var/lib/holoport"
+PREFLIGHT="${HP_PERS}/preflight"
+
+ZEROTIER="/var/lib/zerotier-one"
+
+# Process arguments
+while [[ "${1#-}" != "${1}" ]]; do
+    case "${1}" in
+	--dry-run|-d)
+	    DRYRUN=1
+	    ;;
+	*)
+	    $ERR "Invalid option: ${1}"
+	    exit 1
+    esac
+    shift
+done
+
+# Ensure that our HP_PRS persistence directory exists
+(( DRYRUN )) || [ -d "${HP_PERS}" ] || mkdir -p "${HP_PERS}"
+
+# Try to load current preflight checklist State; default to "initial"
+STATE=$( cat "${PREFLIGHT}" 2>/dev/null )
+STATE=${STATE:-initial}
+BACKUP="${HP_PERS}/backup/${STATE}"	# Store copies of mutated files here
+
+# log "some" "argument list"
+log() { logger -sp user.notice  -t "${0##*/}:        " "${*}"; }
+wrn() { logger -sp user.warning -t "${0##*/}: WARNING" "${*}"; }
+err() { logger -sp user.error   -t "${0##*/}:   ERROR" "${*}"; }
+
+# backup file [description]
+backup() {
+    if [ -a "${1}" ]; then
+	if [ ! -d "${BACKUP}" ]; then
+	    log "Backing up modified files to ${BACKUP} (to restore, run: sudo rsync -va --dry-run ${BACKUP}/ /)"
+	    (( DRYRUN )) || mkdir -p "${BACKUP}"
+	fi
+	wrn "${2:-Copying file} (backing up ${1})"
+	rsync ${DRYRUN:+--dry-run} -aR "${1}" "${BACKUP}/" # keeps full relative/absolute path
+    fi
+}
+
+# Evaluate the system STATE as found in the PREFLIGHT file.  Any files requiring modification or
+# removal will first be copied into the HP_PERS persistence backup directory,
+# eg. /var/lib/holoport/backup/initial/...
+case "${STATE}" in
+    initial)
+	# In the initial state (no previous holoport-preflight run), we need to remove any "default"
+	# factory identities that were shipped with the image.  This includes ZeroTier networking,
+	# SSH host keys, etc.
+	log "Clearing initial factory configurations"
+	for f in identity.public identity.secret authtoken.secret; do
+	    if [ -a    "${ZEROTIER}/${f}" ]; then
+		backup "${ZEROTIER}/${f}" "Removing default ZeroTier configuration"
+		(( DRYRUN )) || rm -f "${ZEROTIER}/${f}"
+	    fi
+	done
+	for f in /etc/ssh/ssh_host_*; do 
+	    backup "${f}" "Removing default SSH Host key"
+	    (( DRYRUN )) || rm -f "${f}"
+	done
+	;& # fall thru
+    # ... Add each new STAT
+    ${CURRENT})
+        log "HoloPortOS Configuration State is CURRENT: ${CURRENT}"
+	;;
+
+    *)
+	err "Unknown State: '${STATE}'; Not repairing!"
+	log "  To fix, check/repair system manually, and store '${CURRENT}' in ${PREFLIGHT} to restore functionality)"
+    	exit 0
+        ;;
+esac
+
+# Finally, note that the system's preflight checklist state is CURRENT
+(( DRYRUN )) || echo "${CURRENT}" > "${PREFLIGHT}"
+
+exit 0


### PR DESCRIPTION
Attempt to run a HoloPortOS "Preflight" checklist, to check and repair any issues that have been detected since the last deployment of the `scripts/holoport-preflight.sh` script.

- The testing procedure doesn't seem to provide access to any new binaries provisioned in the nix pkgs stanza of base.nix; eg. `rsync`, `logger`.
- sshd.service and zerotier.service should probably be restarted, so new host keys and ZeroTier identity gets immediately created and used; this doesn't occur on automatic update (because these services are already running).

Also, changes the `systemd-activation` to `holochain-activation`, which gets its functionality from `scripts/holochain-activation.sh`.  Furthermore -- this is changed to a simple "oneshot" systemd service that is invoked by a `requires = ...` dependency from `holochain.service`.

Ensure that any service that may have its configuration modified by any phase of `holoport-preflight` is mentioned in the `before = ...` stanza, to ensure the Preflight configuration changes occur before that service starts!

Since this, of course, doesn't affect already-running services -- when we dynamically upgrade a host to a new version of holoportos, the affected services will continue to run their old configurations until restarted, or the next reboot.  If a service must be restarted, we have to do it manually.

This affects, specifically, the ZeroTier networking.  By wiping out the (default) identity.secret, we're going to lose access to the ZeroTier network, 'til the new identity is approved in ZeroTier, and entered into the cloudflare KV stores w/ the new IP address.  