### PR TITLE
holoportos-upgrade: exit on command failure

### DIFF
--- a/modules/default.nix
+++ b/modules/default.nix
@@ -57,6 +57,8 @@ in
     ];
 
     script = ''
+      set -e
+
       rm -r /etc/nixos
       mkdir /etc/nixos
 


### PR DESCRIPTION
We need to fail the service when one of the command fails.